### PR TITLE
fix datetime format validation

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -403,8 +403,11 @@ class Validator
         if ($data === null) {
             return false;
         }
-        $data = \DateTime::createFromFormat($format, $data);
-        if ($data === false) {
+        $datatime = \DateTime::createFromFormat($format, $data);
+        if ($datatime === false) {
+            return false;
+        }
+        if($datatime->format($format) !== $data){
             return false;
         }
         $lastErrors = \DateTime::getLastErrors();


### PR DESCRIPTION
When the format is 'Y-m-d' and the value is '023-01-10' it should return false, however it returns true.